### PR TITLE
Use "musl-dev" Alpine package when building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ ENV GOROOT=/usr/lib/go \
 
 ADD main.go /gopath/src/github.com/rubenv/ec2-disable-source-dest/
 
-RUN apk add --update go git openssh && \
+RUN apk add --update go git openssh musl-dev && \
     go get -v github.com/rubenv/ec2-disable-source-dest/... && \
     go install -v github.com/rubenv/ec2-disable-source-dest && \
-    apk del go git openssh && \
+    apk del go git openssh musl-dev && \
     mv $GOPATH/bin/ec2-disable-source-dest /usr/bin/ && \
     rm -rf $GOPATH && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
Without this package included, [the build fails](https://hub.docker.com/r/rubenv/ec2-disable-source-dest/builds/boxnhmdp2rtdrsa5q2zrmjf/) to run _link_ correctly, producing the following error:
```
/usr/lib/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/lib/gcc/x86_64-alpine-linux-musl/6.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find Scrt1.o: No such file or directory
/usr/lib/gcc/x86_64-alpine-linux-musl/6.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find crti.o: No such file or directory
/usr/lib/gcc/x86_64-alpine-linux-musl/6.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lpthread
/usr/lib/gcc/x86_64-alpine-linux-musl/6.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lssp_nonshared
collect2: error: ld returned 1 exit status
```