### PR TITLE
Reduce dependencies for SSL certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,17 @@
-FROM alpine:latest
-MAINTAINER Ruben Vermeersch <ruben@rocketeer.be>
+# Stage: build
+FROM golang:alpine AS build
 
-ENV GOROOT=/usr/lib/go \
-    GOPATH=/gopath     \
-    GOBIN=/gopath/bin  \
-    PATH=$PATH:$GOROOT/bin:$GOPATH/bin \
-    CGO_ENABLED=0
+RUN apk add --no-cache git upx
 
-ADD main.go /gopath/src/github.com/rubenv/ec2-disable-source-dest/
+WORKDIR /go/src/app
+COPY *.go ./
+RUN go get -d -v ./...
 
-RUN apk add --update go git openssh musl-dev && \
-    go get -v github.com/rubenv/ec2-disable-source-dest/... && \
-    go install -v github.com/rubenv/ec2-disable-source-dest && \
-    apk del go git openssh musl-dev && \
-    mv $GOPATH/bin/ec2-disable-source-dest /usr/bin/ && \
-    rm -rf $GOPATH && \
-    rm -rf /var/cache/apk/*
+RUN CGO_ENABLED=0 go build -o disable-check -v main.go
+RUN upx --brute disable-check
 
-CMD ["ec2-disable-source-dest"]
+# Stage: package
+FROM scratch
+LABEL maintainer="Ruben Vermeersch <ruben@rocketeer.be>"
+COPY --from=build /go/src/app/disable-check /
+ENTRYPOINT ["/disable-check"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,11 @@ RUN upx --brute disable-check
 # Stage: package
 FROM scratch
 LABEL maintainer="Ruben Vermeersch <ruben@rocketeer.be>"
+# NB: We deliberately don't place this file in a directory normally
+# searched by Go's "crypto/x509" package, so that overriding the
+# SSL_CERT_FILE environment variable will not allow the package to
+# mistakenly still include this file anyway.
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /certs/
+ENV SSL_CERT_FILE /certs/ca-certificates.crt
 COPY --from=build /go/src/app/disable-check /
 ENTRYPOINT ["/disable-check"]

--- a/README.md
+++ b/README.md
@@ -1,46 +1,96 @@
 # ec2-disable-source-dest
 
-Small helper to disable the EC2 source/dest check from within an instance.
+Small helper to [disable the network interface source/destination
+check](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#change_source_dest_check)
+from within an AWS EC2 instance.
 
 ## Why?
 
-Imagine you're setting up a [Kubernetes](http://kubernetes.io/) cluster, one
-that scales automatically. On [Amazon EC2](https://aws.amazon.com/ec2/), you'd
-do that with an autoscaling group.
+Imagine you're setting up a [Kubernetes](http://kubernetes.io/)
+cluster, one that scales automatically. On [Amazon
+EC2](https://aws.amazon.com/ec2/), you'd do that with an autoscaling
+group.
 
-Depending on your network configuration, you'll need to disable source/dest
-checking on your instance. You can do this manually in the config panel. But
-you can't do it in the launch configuration of the autoscaling group.
+Depending on your network configuration, you may need to disable
+source/destination checking on your instance. You can do this manually
+in the console or at launch time for individual instances, but you
+can't do it in the launch configuration of an autoscaling group.
 
-This little helper reconfigures your instances once they have booted, so you
-don't have to worry about it.
+This helper program reconfigures your instances once they have booted,
+so you don't have to worry about it.
 
 ## Usage
 
 Simply run it inside your EC2 instance:
 
+```shell
+docker run  \
+  --mount type=bind,source=/etc/ssl/certs/ca-certificates.crt,destination=/etc/ssl/certs,readonly \
+  -e 'SSL_CERT_DIR=/etc/ssl/certs' \
+  --net=host \
+  --rm \
+  rubenv/ec2-disable-source-dest
 ```
-docker run --rm rubenv/ec2-disable-source-dest
-```
+Note that this image does not include SSL certificates required to
+trust the AWS EC2 API hosts. Be sure to [mount certificates you trust into the container](https://docs.docker.com/storage/bind-mounts/#use-a-read-only-bind-mount).
 
-You'll need to set up an appropriate IAM role/policy that is capable of using
-`ec2:ModifyInstanceAttribute`.
+You'll need to set up an appropriate IAM role/policy for these
+instances that is capable of using [the `ec2:ModifyInstanceAttribute`
+action](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyInstanceAttribute.html).
 
-## Running on boot (CoreOS)
+## Running on boot (Container Linux)
 
-Add the following unit file to your cloud-config:
-
+Add the following systemd unit file to your cloud-config or Ignition
+configuration:
 ```
 [Unit]
-Description=Disable EC2 source/dest check
-Requires=docker.service
-After=docker.service
+Description=AWS EC2 instance network configuration adjustment
+After=network-online.target
+Requires=network-online.target
+ConditionPathExists=!/.disabled-src-dest-check
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/docker run --rm rubenv/ec2-disable-source-dest
+# Optimization: Even though we'll only use one file, Go's
+# "crypto/x509" package will always scan at least one directory, even
+# when pointed at a specific file with the related SSL_CERT_FILE
+# variable. Rather than reading that file first and nominating a
+# nonexistent directory, point it at the directory and let it find the
+# one file there.
+Environment=SSL_CERT_DIR=/etc/ssl/certs
+ExecStart=/usr/bin/sudo /usr/bin/rkt --insecure-options=image run \
+  --net=host \
+  --dns=host \
+  --volume certs,kind=host,source=/etc/ssl/certs/ca-certificates.crt,readOnly=true \
+  --mount  volume=certs,target=/etc/ssl/certs/ca-certificates.crt \
+  docker://rubenv/ec2-disable-source-dest
+ExecStartPost=/usr/bin/touch /.disabled-src-dest-check
+ExecStartPost=-/usr/bin/sudo /usr/bin/rkt gc --grace-period=0s
 
 [Install]
 WantedBy=multi-user.target
 ```
+Consider pulling [the _rubenv/ec2-disable-source-dest_ image](https://hub.docker.com/r/rubenv/ec2-disable-source-dest/) ahead of
+time when building your AMI:
+```shell
+#!/bin/sh
+
+set -e -u
+
+for image in \
+  docker://rubenv/ec2-disable-source-dest;
+do
+  case "${image}" in
+    docker://*) opts='--insecure-options=image';;
+    *)          opts=;;
+  esac
+  rkt "${opts}" fetch "${image}"
+done
+```
+Note that it is possible to go even further and use [_rkt prepare_](https://coreos.com/rkt/docs/latest/subcommands/prepare.html) when
+building your AMI and [_rkt
+run-prepared_](https://coreos.com/rkt/docs/latest/subcommands/run-prepared.html)
+at boot time in lieu of _rkt run_, but that allows the systemd unit to
+run no more than once&mdash;absent another intervening invocation of
+_rkt prepare_. If it fails, it's then harder to run it again.


### PR DESCRIPTION
I was uncomfortable with the use of [the _github.com/certifi/gocertifi_ Go package](https://github.com/certifi/gocertifi), locking SSL certificates into the Docker image. I think it's safer to provide certificates from the host machine when running a container.

Find here removal of that Go package in favor of allowing the _crypto/x509_ package to load certificates as guided by [the SSL_CERT_FILE and SSL_CERT_DIR environment variables](https://golang.org/src/crypto/x509/root_unix.go).

I also revised the _Dockerfile_ to use a multi-stage build. The resulting image is about one eighth the size of the original image, though it does take _upx_ a while to do its shrinking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rubenv/ec2-disable-source-dest/2)
<!-- Reviewable:end -->
